### PR TITLE
Remove css vars for tooltip and toggle, remove tooltip color props

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,17 +97,14 @@ The wrapper around your fields.
 
 The common API is shared among all <Field /> elements. Type specific fields are found below.
 
-| Prop              | Type                | Default | Description                                                                                                                               |
-| ----------------- | ------------------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
-| type              | string              | 'text'  | Can be any of the following types: text (default), email, number, select, password, textarea, tags, markdown, toggle. (See types below)   |
-| name              | string              | ''      | The name of the field data to be returned. If no name prop is given, the Field element's text will be converted to camelCase and be used. |
-| required          | boolean             | false   | If a field is required                                                                                                                    |
-| label             | boolean             | true    | If a field has a label                                                                                                                    |
-| defaultValue      | string/number/array | null    | The initial value for each field                                                                                                          |
-| tooltip           | string              | ''      | Shows an info icon next to the label with a tooltip message on hover                                                                      |
-| tooltipBackground | string              | '#eee'  | Background color for tooltip message.                                                                                                     |
-| tooltipColor      | string              | '#000'  | Font color for tooltip message.                                                                                                           |
-| tooltipIconColor  | string              | '#000'  | Font color for tooltip icon on the label.                                                                                                 |
+| Prop         | Type                | Default | Description                                                                                                                               |
+| ------------ | ------------------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| type         | string              | 'text'  | Can be any of the following types: text (default), email, number, select, password, textarea, tags, markdown, toggle. (See types below)   |
+| name         | string              | ''      | The name of the field data to be returned. If no name prop is given, the Field element's text will be converted to camelCase and be used. |
+| required     | boolean             | false   | If a field is required                                                                                                                    |
+| label        | boolean             | true    | If a field has a label                                                                                                                    |
+| defaultValue | string/number/array | null    | The initial value for each field                                                                                                          |
+| tooltip      | string              | ''      | Shows an info icon next to the label with a tooltip message on hover                                                                      |
 
 #### type - text & textarea
 

--- a/src/Field.tsx
+++ b/src/Field.tsx
@@ -38,9 +38,6 @@ const Field = ({
   defaultValue = '',
   displayProperty = '',
   tooltip,
-  tooltipBackground,
-  tooltipColor,
-  tooltipIconColor,
 }: FieldInterface) => {
   const fieldId = name || camelCase(children)
 
@@ -63,14 +60,7 @@ const Field = ({
       <label className="fresh-label" htmlFor={`fresh-${fieldId}`}>
         <span className="fresh-title">
           {required && '*'} {label && children}&nbsp;
-          {tooltip && (
-            <Tooltip
-              tooltip={tooltip}
-              tooltipBackground={tooltipBackground}
-              tooltipColor={tooltipColor}
-              tooltipIconColor={tooltipIconColor}
-            />
-          )}
+          {tooltip && <Tooltip tooltip={tooltip} />}
         </span>
         {(() => {
           switch (type) {
@@ -110,9 +100,6 @@ Field.defaultProps = {
   defaultValue: null,
   options: [],
   tooltip: '',
-  tooltipBackground: '#eee',
-  tooltipColor: '#000',
-  tooltipIconColor: '#000',
 }
 
 export default Field

--- a/src/fields/types.ts
+++ b/src/fields/types.ts
@@ -17,8 +17,5 @@ export interface FieldInterface {
   defaultValue?: string | boolean | number | [] | RefValue | {}
   tooltip?: string
   strength?: boolean
-  tooltipBackground?: string
-  tooltipColor?: string
-  tooltipIconColor?: string
   displayProperty?: string
 }

--- a/src/style.tsx
+++ b/src/style.tsx
@@ -1,11 +1,6 @@
 import { createGlobalStyle } from 'styled-components'
 
 const Global = createGlobalStyle`
-  :root {
-    --fresh-tooltip-color: #000;
-    --fresh-tooltip-background: #eee;
-  }
-
   .fresh-switch {
     position: relative;
     display: inline-block;
@@ -123,7 +118,7 @@ const Global = createGlobalStyle`
     align-items: center;
     .fresh-tooltip {
       position: relative;
-      color: var(--fresh-tooltip-color);
+      color: #000;
       &:after {
         position: absolute;
         left: 150%;
@@ -134,7 +129,7 @@ const Global = createGlobalStyle`
         visibility: hidden;
         z-index: 2;
         position: absolute;
-        background-color: var(--fresh-tooltip-background);
+        background-color: #eee;
         padding: 0.75em;
         border-radius: 3px;
         font-size: 0.8em;
@@ -201,22 +196,12 @@ const Global = createGlobalStyle`
       left: 0;
       right: 0;
       bottom: 0;
-      background-color: var(--fresh-toggle-color);
       transition: 0.4s;
       border-width: 1px;
       border-style: solid;
       border-image: initial;
       border-color: inherit;
       border-radius: 34px;
-      &.on {
-        background-color: var(--fresh-toggle-on-color);
-        &:focus {
-          box-shadow: 0 0 1px var(--fresh-toggle-on-color);
-        }
-        &:before {
-          transform: translateX(26px);
-        }
-      }
       &:before {
         position: absolute;
         content: '';


### PR DESCRIPTION
- remove non-existant css vars being referenced for toggle in style.tsx file
- remove css vars for tooltip because they cannot be over-ridden
-remove props for tooltip colors since css vars cannot be used with them